### PR TITLE
Provide default version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 from setuptools import find_packages
 from setuptools import setup
 
-with open('.version') as f:
-    VERSION = f.readline().strip()
+try:
+    with open('.version') as f:
+        VERSION = f.readline().strip()
+except IOError:
+    VERSION = 'unknown'
+
 setup(
     name='create',
     version=VERSION,


### PR DESCRIPTION
If the autoversion target hasn't run, this causes setup.py to fail. The one
target that doesn't depend on autoversion is update-requirements, but this is
the way ocfweb does things.