### PR TITLE
Enable SSL verification for redis

### DIFF
--- a/create/global_healthcheck.py
+++ b/create/global_healthcheck.py
@@ -34,14 +34,13 @@ def celery_app():
         broker=conf.get('celery', 'broker'),
         backend=conf.get('celery', 'backend'),
     )
-    # TODO: use ssl verification
     celery.conf.broker_use_ssl = {
-        'ssl_cert_reqs': ssl.CERT_NONE,
+        'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
     }
-    # `redis_backend_use_ssl` is an OCF patch which was proposed upstream:
-    # https://github.com/celery/celery/pull/3831
     celery.conf.redis_backend_use_ssl = {
-        'ssl_cert_reqs': ssl.CERT_NONE,
+        'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
     }
 
     # TODO: stop using pickle

--- a/create/healthcheck.py
+++ b/create/healthcheck.py
@@ -24,14 +24,13 @@ def celery_app():
         broker=conf.get('celery', 'broker'),
         backend=conf.get('celery', 'backend'),
     )
-    # TODO: use ssl verification
     celery.conf.broker_use_ssl = {
-        'ssl_cert_reqs': ssl.CERT_NONE,
+        'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
     }
-    # `redis_backend_use_ssl` is an OCF patch which was proposed upstream:
-    # https://github.com/celery/celery/pull/3831
     celery.conf.redis_backend_use_ssl = {
-        'ssl_cert_reqs': ssl.CERT_NONE,
+        'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
     }
 
     # TODO: stop using pickle

--- a/create/tasks.py
+++ b/create/tasks.py
@@ -26,12 +26,13 @@ celery = Celery(
     broker=conf.get('celery', 'broker'),
     backend=conf.get('celery', 'backend'),
 )
-# TODO: use ssl verification
 celery.conf.broker_use_ssl = {
-    'ssl_cert_reqs': ssl.CERT_NONE,
+    'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+    'ssl_cert_reqs': ssl.CERT_REQUIRED,
 }
 celery.conf.redis_backend_use_ssl = {
-    'ssl_cert_reqs': ssl.CERT_NONE,
+    'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+    'ssl_cert_reqs': ssl.CERT_REQUIRED,
 }
 
 # TODO: stop using pickle


### PR DESCRIPTION
rt#5886

Seems work fine when testing connecting to redis with the task queue, and both health checks still work, so I think this is good to go.

Same as https://github.com/ocf/ocfweb/pull/330, https://github.com/ocf/approve/pull/4, and https://github.com/ocf/ircbot/commit/ca9483b04d4b7.