### PR TITLE
Reduce to 1 replica to help debugging kerberos issue

### DIFF
--- a/kubernetes/create-deployment.yml.erb
+++ b/kubernetes/create-deployment.yml.erb
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: create
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: create


### PR DESCRIPTION
There is currently a kerberos timeout issue in create (see recent rootspam). This change would reduce the number of log files, and kubernetes pods we need to worry about by 2/3. 